### PR TITLE
Update date format

### DIFF
--- a/src/main/java/reposense/parser/DateArgumentType.java
+++ b/src/main/java/reposense/parser/DateArgumentType.java
@@ -13,7 +13,9 @@ import reposense.util.TimeUtil;
  * Verifies and parses a string-formatted date to a {@link LocalDateTime} object.
  */
 public class DateArgumentType implements ArgumentType<Optional<LocalDateTime>> {
-    protected static final String PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT = "Invalid Date: %s";
+    private static final String PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT = "Invalid Date: %s";
+    protected static final String EXTRACT_EXCEPTION_MESSAGE_INVALID_DATE_FORMAT = "Invalid Date Format: %s. Please " +
+            "read usage guide above.";
 
     @Override
     public Optional<LocalDateTime> convert(ArgumentParser parser, Argument arg, String value)

--- a/src/main/java/reposense/parser/DateArgumentType.java
+++ b/src/main/java/reposense/parser/DateArgumentType.java
@@ -13,8 +13,10 @@ import reposense.util.TimeUtil;
  * Verifies and parses a string-formatted date to a {@link LocalDateTime} object.
  */
 public class DateArgumentType implements ArgumentType<Optional<LocalDateTime>> {
-    protected static final String EXTRACT_EXCEPTION_MESSAGE_INVALID_DATE_FORMAT =
-            "Invalid Date Format: %s. Please read usage guide above.";
+    protected static final String EXTRACT_EXCEPTION_MESSAGE_INVALID_DATE_FORMAT = "Invalid Date: %s\n"
+            + "Year must be within 1900 - 2999.\n"
+            + "Accepted formats: [d]d/[M]M/yyyy. For example: 01/01/2022 or 1/1/2022.\n"
+            + "Accepted delimiters: '/', '-', '.'. For example: 1/1/2022 or 1-1-2022.";
     private static final String PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT = "Invalid Date: %s";
 
     @Override

--- a/src/main/java/reposense/parser/DateArgumentType.java
+++ b/src/main/java/reposense/parser/DateArgumentType.java
@@ -13,9 +13,9 @@ import reposense.util.TimeUtil;
  * Verifies and parses a string-formatted date to a {@link LocalDateTime} object.
  */
 public class DateArgumentType implements ArgumentType<Optional<LocalDateTime>> {
+    protected static final String EXTRACT_EXCEPTION_MESSAGE_INVALID_DATE_FORMAT =
+            "Invalid Date Format: %s. Please read usage guide above.";
     private static final String PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT = "Invalid Date: %s";
-    protected static final String EXTRACT_EXCEPTION_MESSAGE_INVALID_DATE_FORMAT = "Invalid Date Format: %s. Please " +
-            "read usage guide above.";
 
     @Override
     public Optional<LocalDateTime> convert(ArgumentParser parser, Argument arg, String value)

--- a/src/main/java/reposense/parser/DateArgumentType.java
+++ b/src/main/java/reposense/parser/DateArgumentType.java
@@ -13,7 +13,7 @@ import reposense.util.TimeUtil;
  * Verifies and parses a string-formatted date to a {@link LocalDateTime} object.
  */
 public class DateArgumentType implements ArgumentType<Optional<LocalDateTime>> {
-    private static final String PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT = "Invalid Date: %s";
+    protected static final String PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT = "Invalid Date: %s";
 
     @Override
     public Optional<LocalDateTime> convert(ArgumentParser parser, Argument arg, String value)

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -43,7 +43,7 @@ public class SinceDateArgumentType extends DateArgumentType {
         String sinceDate = TimeUtil.extractDate(value);
         if (sinceDate.equals(TimeUtil.INVALID_DATE)) {
             throw new ArgumentParserException(
-                    String.format(PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT, value), parser);
+                    String.format(EXTRACT_EXCEPTION_MESSAGE_INVALID_DATE_FORMAT, value), parser);
         }
 
         return super.convert(parser, arg, sinceDate + " 00:00:00");

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -39,7 +39,13 @@ public class SinceDateArgumentType extends DateArgumentType {
         if (FIRST_COMMIT_DATE_SHORTHAND.equals(value)) {
             return Optional.of(ARBITRARY_FIRST_COMMIT_DATE_LOCAL);
         }
+
         String sinceDate = TimeUtil.extractDate(value);
+        if (sinceDate.equals(TimeUtil.INVALID_DATE)) {
+            throw new ArgumentParserException(
+                    String.format(PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT, value), parser);
+        }
+
         return super.convert(parser, arg, sinceDate + " 00:00:00");
     }
 

--- a/src/main/java/reposense/parser/UntilDateArgumentType.java
+++ b/src/main/java/reposense/parser/UntilDateArgumentType.java
@@ -17,6 +17,11 @@ public class UntilDateArgumentType extends DateArgumentType {
     public Optional<LocalDateTime> convert(ArgumentParser parser, Argument arg, String value)
             throws ArgumentParserException {
         String untilDate = TimeUtil.extractDate(value);
+        if (untilDate.equals(TimeUtil.INVALID_DATE)) {
+            throw new ArgumentParserException(
+                    String.format(PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT, value), parser);
+        }
+
         return super.convert(parser, arg, untilDate + " 23:59:59");
     }
 }

--- a/src/main/java/reposense/parser/UntilDateArgumentType.java
+++ b/src/main/java/reposense/parser/UntilDateArgumentType.java
@@ -19,7 +19,7 @@ public class UntilDateArgumentType extends DateArgumentType {
         String untilDate = TimeUtil.extractDate(value);
         if (untilDate.equals(TimeUtil.INVALID_DATE)) {
             throw new ArgumentParserException(
-                    String.format(PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT, value), parser);
+                    String.format(EXTRACT_EXCEPTION_MESSAGE_INVALID_DATE_FORMAT, value), parser);
         }
 
         return super.convert(parser, arg, untilDate + " 23:59:59");

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -17,7 +17,7 @@ import reposense.parser.SinceDateArgumentType;
 public class TimeUtil {
     private static Long startTime;
     private static final String DATE_FORMAT_REGEX =
-            "^((0[1-9]|[12][0-9]|3[01])\\/(0[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
+            "^((0?[1-9]|[12][0-9]|3[01])\\/(0?[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
 
     // "uuuu" is used for year since "yyyy" does not work with ResolverStyle.STRICT
     private static final DateTimeFormatter CLI_ARGS_DATE_FORMAT = DateTimeFormatter.ofPattern("d/M/uuuu HH:mm:ss");

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -15,6 +15,8 @@ import reposense.parser.SinceDateArgumentType;
  * Contains time related functionalities.
  */
 public class TimeUtil {
+    public static final String INVALID_DATE = "invalid date";
+
     private static Long startTime;
     private static final String DATE_FORMAT_REGEX =
             "^((0?[1-9]|[12][0-9]|3[01])\\/(0?[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
@@ -25,8 +27,6 @@ public class TimeUtil {
             "\"Since Date\" cannot be later than \"Until Date\".";
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_TODAY_DATE =
             "\"Since Date\" must not be later than today's date.";
-
-    public static final String INVALID_DATE = "invalid date";
 
     /**
      * Sets the {@code startTime} to be the current time.

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -16,8 +16,10 @@ import reposense.parser.SinceDateArgumentType;
  */
 public class TimeUtil {
     public static final String INVALID_DATE = "invalid date";
-    private static final String DATE_FORMAT_REGEX =
+    private static final String DATE_FORMAT_DAY_MONTH_YEAR_REGEX =
             "^((0?[1-9]|[12]\\d|3[01])[/.-](0?[1-9]|1[012])[/.-]((19|2\\d)\\d{2}))";
+    private static final String DATE_FORMAT_YEAR_MONTH_DAY_REGEX =
+            "^(((19|2\\d)\\d{2})[/.-](0?[1-9]|1[012])[/.-]([12]\\d|3[01]|0?[1-9]))";
     // "uuuu" is used for year since "yyyy" does not work with ResolverStyle.STRICT
     private static final DateTimeFormatter CLI_ARGS_DATE_FORMAT = DateTimeFormatter.ofPattern("d/M/uuuu HH:mm:ss");
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =
@@ -165,16 +167,28 @@ public class TimeUtil {
 
     /**
      * Extracts the date and reformats into {@link TimeUtil#STANDARD_DATE_FORMAT} if {@code date} string matches the
-     * {@link TimeUtil#DATE_FORMAT_REGEX}. Else returns {@link TimeUtil#INVALID_DATE}.
+     * {@link TimeUtil#DATE_FORMAT_DAY_MONTH_YEAR_REGEX} or {@link TimeUtil#DATE_FORMAT_YEAR_MONTH_DAY_REGEX}. Else
+     * returns {@link TimeUtil#INVALID_DATE}.
      */
     public static String extractDate(String date) {
-        Matcher matcher = Pattern.compile(DATE_FORMAT_REGEX).matcher(date);
-        String extractedDate = INVALID_DATE;
+        Matcher matcher1 = Pattern.compile(DATE_FORMAT_DAY_MONTH_YEAR_REGEX).matcher(date);
+        Matcher matcher2 = Pattern.compile(DATE_FORMAT_YEAR_MONTH_DAY_REGEX).matcher(date);
 
-        if (matcher.find()) {
-            String day = matcher.group(2);
-            String month = matcher.group(3);
-            String year = matcher.group(4);
+        String extractedDate = INVALID_DATE;
+        String year;
+        String month;
+        String day;
+
+        if (matcher1.find()) {
+            day = matcher1.group(2);
+            month = matcher1.group(3);
+            year = matcher1.group(4);
+
+            extractedDate = String.format(STANDARD_DATE_FORMAT, day, month, year);
+        } else if (matcher2.find()) {
+            day = matcher2.group(5);
+            month = matcher2.group(4);
+            year = matcher2.group(2);
 
             extractedDate = String.format(STANDARD_DATE_FORMAT, day, month, year);
         }

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -16,17 +16,16 @@ import reposense.parser.SinceDateArgumentType;
  */
 public class TimeUtil {
     public static final String INVALID_DATE = "invalid date";
-
-    private static Long startTime;
     private static final String DATE_FORMAT_REGEX =
-            "^((0?[1-9]|[12][0-9]|3[01])\\/(0?[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
-
+            "^((0?[1-9]|[12][0-9]|3[01])\\/(0?[1-9]|1[012])\\/((19|2[0-9])[0-9]{2}))";
     // "uuuu" is used for year since "yyyy" does not work with ResolverStyle.STRICT
     private static final DateTimeFormatter CLI_ARGS_DATE_FORMAT = DateTimeFormatter.ofPattern("d/M/uuuu HH:mm:ss");
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =
             "\"Since Date\" cannot be later than \"Until Date\".";
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_TODAY_DATE =
             "\"Since Date\" must not be later than today's date.";
+    private static final String STANDARD_DATE_FORMAT = "%s/%s/%s";
+    private static Long startTime;
 
     /**
      * Sets the {@code startTime} to be the current time.
@@ -170,9 +169,15 @@ public class TimeUtil {
     public static String extractDate(String date) {
         Matcher matcher = Pattern.compile(DATE_FORMAT_REGEX).matcher(date);
         String extractedDate = INVALID_DATE;
+
         if (matcher.find()) {
-            extractedDate = matcher.group(1);
+            String day = matcher.group(2);
+            String month = matcher.group(3);
+            String year = matcher.group(4);
+
+            extractedDate = String.format(STANDARD_DATE_FORMAT, day, month, year);
         }
+
         return extractedDate;
     }
 

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -164,7 +164,8 @@ public class TimeUtil {
     }
 
     /**
-     * Extracts the first substring of {@code date} string that matches the {@code DATE_FORMAT_REGEX}.
+     * Extracts the date and reformats into {@link TimeUtil#STANDARD_DATE_FORMAT} if {@code date} string matches the
+     * {@link TimeUtil#DATE_FORMAT_REGEX}. Else returns {@link TimeUtil#INVALID_DATE}.
      */
     public static String extractDate(String date) {
         Matcher matcher = Pattern.compile(DATE_FORMAT_REGEX).matcher(date);

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -17,7 +17,7 @@ import reposense.parser.SinceDateArgumentType;
 public class TimeUtil {
     public static final String INVALID_DATE = "invalid date";
     private static final String DATE_FORMAT_REGEX =
-            "^((0?[1-9]|[12][0-9]|3[01])[\\/.-](0?[1-9]|1[012])[\\/.-]((19|2[0-9])[0-9]{2}))";
+            "^((0?[1-9]|[12]\\d|3[01])[/.-](0?[1-9]|1[012])[/.-]((19|2\\d)\\d{2}))";
     // "uuuu" is used for year since "yyyy" does not work with ResolverStyle.STRICT
     private static final DateTimeFormatter CLI_ARGS_DATE_FORMAT = DateTimeFormatter.ofPattern("d/M/uuuu HH:mm:ss");
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -17,7 +17,7 @@ import reposense.parser.SinceDateArgumentType;
 public class TimeUtil {
     public static final String INVALID_DATE = "invalid date";
     private static final String DATE_FORMAT_REGEX =
-            "^((0?[1-9]|[12][0-9]|3[01])\\/(0?[1-9]|1[012])\\/((19|2[0-9])[0-9]{2}))";
+            "^((0?[1-9]|[12][0-9]|3[01])[\\/.-](0?[1-9]|1[012])[\\/.-]((19|2[0-9])[0-9]{2}))";
     // "uuuu" is used for year since "yyyy" does not work with ResolverStyle.STRICT
     private static final DateTimeFormatter CLI_ARGS_DATE_FORMAT = DateTimeFormatter.ofPattern("d/M/uuuu HH:mm:ss");
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -26,6 +26,8 @@ public class TimeUtil {
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_TODAY_DATE =
             "\"Since Date\" must not be later than today's date.";
 
+    public static final String INVALID_DATE = "invalid date";
+
     /**
      * Sets the {@code startTime} to be the current time.
      */
@@ -167,7 +169,7 @@ public class TimeUtil {
      */
     public static String extractDate(String date) {
         Matcher matcher = Pattern.compile(DATE_FORMAT_REGEX).matcher(date);
-        String extractedDate = date;
+        String extractedDate = INVALID_DATE;
         if (matcher.find()) {
             extractedDate = matcher.group(1);
         }

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -11,7 +11,11 @@ public class TimeUtilTest {
     @Test
     public void extractDate_validDate_success() {
         String expectedDate = "20/05/2019";
+
         String actualDate = TimeUtil.extractDate(expectedDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("2019/05/20");
         Assertions.assertEquals(expectedDate, actualDate);
     }
 
@@ -19,7 +23,11 @@ public class TimeUtilTest {
     public void extractDate_validDateAndTime_success() {
         String originalDateAndTime = "20/05/2020 12:34:56";
         String expectedDate = "20/05/2020";
+
         String actualDate = TimeUtil.extractDate(originalDateAndTime);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("2020/05/20 12:34:56");
         Assertions.assertEquals(expectedDate, actualDate);
     }
 
@@ -29,12 +37,21 @@ public class TimeUtilTest {
         String actualDate = TimeUtil.extractDate(expectedDate);
         Assertions.assertEquals(expectedDate, actualDate);
 
+        actualDate = TimeUtil.extractDate("2020/05/1");
+        Assertions.assertEquals(expectedDate, actualDate);
+
         expectedDate = "01/5/2020";
         actualDate = TimeUtil.extractDate(expectedDate);
         Assertions.assertEquals(expectedDate, actualDate);
 
+        actualDate = TimeUtil.extractDate("2020/5/01");
+        Assertions.assertEquals(expectedDate, actualDate);
+
         expectedDate = "1/5/2020";
         actualDate = TimeUtil.extractDate(expectedDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("2020/5/1");
         Assertions.assertEquals(expectedDate, actualDate);
     }
 
@@ -48,6 +65,12 @@ public class TimeUtilTest {
         actualDate = TimeUtil.extractDate("01.01.2020");
         Assertions.assertEquals(expectedDate, actualDate);
 
+        actualDate = TimeUtil.extractDate("2020-01-01");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("2020.01.01");
+        Assertions.assertEquals(expectedDate, actualDate);
+
         // Mix and match actually also works, but I doubt anyone will use it
         actualDate = TimeUtil.extractDate("01/01.2020");
         Assertions.assertEquals(expectedDate, actualDate);
@@ -56,6 +79,15 @@ public class TimeUtilTest {
         Assertions.assertEquals(expectedDate, actualDate);
 
         actualDate = TimeUtil.extractDate("01-01/2020");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("2020.01/01");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("2020-01.01");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("2020/01-01");
         Assertions.assertEquals(expectedDate, actualDate);
     }
 

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -39,10 +39,42 @@ public class TimeUtilTest {
     }
 
     @Test
+    public void extractDate_validDateWithDifferentDelimiters_success() {
+        String originalDate = "01-01-2020";
+        String expectedDate = "01/01/2020";
+        String actualDate = TimeUtil.extractDate(originalDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        originalDate = "01.01.2020";
+        actualDate = TimeUtil.extractDate(originalDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        // Mix and match actually also works, but I doubt anyone will use it
+        originalDate = "01/01.2020";
+        actualDate = TimeUtil.extractDate(originalDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        originalDate = "01.01-2020";
+        actualDate = TimeUtil.extractDate(originalDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        originalDate = "01-01/2020";
+        actualDate = TimeUtil.extractDate(originalDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
     public void extractDate_invalidDate_throwsParseException() {
+        // Extra digits
         Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("001/02/2020"));
         Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01/002/2020"));
         Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("001/002/2020"));
+
+        // Use delimiter other than '/', '.', and '-'
+        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01?02/2020"));
+        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01/02 2020"));
+        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01@02/2020"));
+        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01/02+2020"));
     }
 
     @Test

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -40,41 +40,51 @@ public class TimeUtilTest {
 
     @Test
     public void extractDate_validDateWithDifferentDelimiters_success() {
-        String originalDate = "01-01-2020";
         String expectedDate = "01/01/2020";
-        String actualDate = TimeUtil.extractDate(originalDate);
+
+        String actualDate = TimeUtil.extractDate("01-01-2020");
         Assertions.assertEquals(expectedDate, actualDate);
 
-        originalDate = "01.01.2020";
-        actualDate = TimeUtil.extractDate(originalDate);
+        actualDate = TimeUtil.extractDate("01.01.2020");
         Assertions.assertEquals(expectedDate, actualDate);
 
         // Mix and match actually also works, but I doubt anyone will use it
-        originalDate = "01/01.2020";
-        actualDate = TimeUtil.extractDate(originalDate);
+        actualDate = TimeUtil.extractDate("01/01.2020");
         Assertions.assertEquals(expectedDate, actualDate);
 
-        originalDate = "01.01-2020";
-        actualDate = TimeUtil.extractDate(originalDate);
+        actualDate = TimeUtil.extractDate("01.01-2020");
         Assertions.assertEquals(expectedDate, actualDate);
 
-        originalDate = "01-01/2020";
-        actualDate = TimeUtil.extractDate(originalDate);
+        actualDate = TimeUtil.extractDate("01-01/2020");
         Assertions.assertEquals(expectedDate, actualDate);
     }
 
     @Test
-    public void extractDate_invalidDate_throwsParseException() {
+    public void extractDate_invalidDate_returnsInvalidDate() {
+        String expectedDate = TimeUtil.INVALID_DATE;
+
         // Extra digits
-        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("001/02/2020"));
-        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01/002/2020"));
-        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("001/002/2020"));
+        String actualDate = TimeUtil.extractDate("001/02/2020");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("01/002/2020");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("001/002/2020");
+        Assertions.assertEquals(expectedDate, actualDate);
 
         // Use delimiter other than '/', '.', and '-'
-        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01?02/2020"));
-        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01/02 2020"));
-        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01@02/2020"));
-        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01/02+2020"));
+        actualDate = TimeUtil.extractDate("01?02/2020");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("01/02 2020");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("01@02/2020");
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        actualDate = TimeUtil.extractDate("01/02+2020");
+        Assertions.assertEquals(expectedDate, actualDate);
     }
 
     @Test

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -24,6 +24,28 @@ public class TimeUtilTest {
     }
 
     @Test
+    public void extractDate_validSingleDigitDate_success() {
+        String expectedDate = "1/05/2020";
+        String actualDate = TimeUtil.extractDate(expectedDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        expectedDate = "01/5/2020";
+        actualDate = TimeUtil.extractDate(expectedDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+
+        expectedDate = "1/5/2020";
+        actualDate = TimeUtil.extractDate(expectedDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    public void extractDate_invalidDate_throwsParseException() {
+        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("001/02/2020"));
+        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("01/002/2020"));
+        Assertions.assertThrows(ParseException.class, () -> TimeUtil.parseDate("001/002/2020"));
+    }
+
+    @Test
     public void parseDate_validDateAndTime_success() throws Exception {
         String originalDateAndTime = "20/05/2020 00:00:00";
         LocalDateTime expectedDate = TestUtil.getSinceDate(2020, Month.MAY.getValue(), 20);


### PR DESCRIPTION
# Phase 2: experiment

## Fix Unexpected Behavior in `TimeUtil`

Original Version (line `169` in `TimeUtil`)

``` java
public static String extractDate(String date) {
        Matcher matcher = Pattern.compile(DATE_FORMAT_REGEX).matcher(date);
        String extractedDate = date;
        if (matcher.find()) {
            extractedDate = matcher.group(1);
        }
        return extractedDate;
    }
```

Potential Problem:

* The input `date` will be returned regardless of the status of the `matcher`.
* Input dates that do not follow `DATE_FORMAT_REGEX`, but are still valid dates, are allowed and will be processed by the program.
* According to `DATE_FORMAT_REGEX`, the accepted input is in the format of `dd/MM/yyyy`.
* However, `1/1/2022` can also be accepted by the program as it is a valid date, but it does not follow the `DATE_FORMAT_REGEX`.

Proposed Fix: `extractedDate` will be initialized to `INVALID_DATE`. If `DATE_FORMAT_REGEX` is matched, then `extractedDate` will be updated to the input `date`.

1. Added in `TimeUtil`.
    ``` java
    public static final String INVALID_DATE = "invalid date";
    ```
1. Updated `extractDate()` in `TimeUtil`.
    ``` java
    public static String extractDate(String date) {
        ...
        String extractedDate = INVALID_DATE;
        ...
    }
    ```
1. Updated `convert()` in `SinceDateArgumentType` and `UntilDateArgumentType`.
    ``` java
    public Optional<LocalDateTime> convert(ArgumentParser parser, Argument arg, String value)
            throws ArgumentParserException {
        ...
        if (sinceDate.equals(TimeUtil.INVALID_DATE)) { // or untilDate
            throw new ArgumentParserException(
                    String.format(EXTRACT_EXCEPTION_MESSAGE_INVALID_DATE_FORMAT, value), parser);
        }
        ...
    }
    ```

## Allow More Date Formats

Although the previous is a logic bug, it is indeed a good feature as different users may use different date formats.
To achieve this, add a `?` after the `0` to make it optional in the regex.

``` java
private static final String DATE_FORMAT_REGEX =
        "^((0?[1-9]|[12][0-9]|3[01])\\/(0?[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
```

This allows users to input single-digit dates like `1/1/2022` instead of `01/01/2022`.

Futhermore, we allow different delimeters such as `.` and `-`.
`/` in `DATE_FORMAT_REGEX` is changed into `[/.-]`.

``` java
private static final String DATE_FORMAT_REGEX =
        "^((0?[1-9]|[12]\\d|3[01])[/.-](0?[1-9]|1[012])[/.-]((19|2\\d)\\d{2}))";
```

This allows users to input dates like `1-1-2022`, `1.1.2022`, or even `1/1.2022`! _(I doubt anyone write in this format though)_

However, the output will be inconsistent as it now depends on the input. To resolve this, `date` that matches `DATE_FORMAT_REGEX` will be reformatted into `STANDARD_DATE_FORMAT`.

``` java
private static final String STANDARD_DATE_FORMAT = "%s/%s/%s";
```

``` java
public static String extractDate(String date) {
    ...
    if (matcher.find()) {
        String day = matcher.group(2);
        String month = matcher.group(3);
        String year = matcher.group(4);

        extractedDate = String.format(STANDARD_DATE_FORMAT, day, month, year);
    }
    ...
}
```

Hence the above inputs, `1-1-2022`, `1.1.2022`, or even `1/1.2022`, will all be reformatted into `1/1/2022`.

Finally, allow users to input `yyyy/mm/dd` other than `dd/mm/yyyy`.
This is achieved by adding another regex.

To avoid confusion, the old `DATE_FORMAT_REGEX` is renamed as `DATE_FORMAT_DAY_MONTH_YEAR_REGEX`. A new regex `DATE_FORMAT_YEAR_MONTH_DAY_REGEX` is then created.

``` java
private static final String DATE_FORMAT_YEAR_MONTH_DAY_REGEX =
        "^(((19|2\\d)\\d{2})[/.-](0?[1-9]|1[012])[/.-]([12]\\d|3[01]|0?[1-9]))";
```

``` java
public static String extractDate(String date) {
    ...
    if (matcher1.find()) {
        ...
    } else if (matcher2.find()) {
        ...
    }
    ...
}
```

# Todo List
- [x] Fix unexpected behavior of `TimeUtil`
- [x] Allow single digit dates (e.g. `1/1/2022`)
- [x] Allow `-` and `.` other than `/`
- [x] Allow `yyyy/mm/dd` other than `dd/mm/yyyy`
- [x] Update test cases
- [x] Update help message
- [x] Update javadoc
- [ ] Update metavar
  - Unsure about the format.
  - Proposed `[d]d(/.-)[M]M(/.-)yyyy`? But it seems confusing.
- [ ] Clean up the code